### PR TITLE
Fixed bug with Directory Separator

### DIFF
--- a/src/WilderBlog/Services/DataProviders/DataProvider.cs
+++ b/src/WilderBlog/Services/DataProviders/DataProvider.cs
@@ -11,7 +11,7 @@ namespace WilderBlog.Services.DataProviders
 
     public DataProvider(IHostingEnvironment env, string path)
     {
-      _path = Path.Combine(env.ContentRootPath, $@"Data\{path}");
+      _path = Path.Combine(env.ContentRootPath, $@"Data{Path.DirectorySeparatorChar}{path}");
     }
 
     public virtual IEnumerable<T> Get()


### PR DESCRIPTION
Tried to run a 'dotnet run' on my MacBook Pro, and got an exception regarding finding the file courses.json.

It was due to \ being used as directory separator instead of Path.DirectorySeparatorChar.